### PR TITLE
Made stream parameter optional in create method

### DIFF
--- a/src/Pdf/index.js
+++ b/src/Pdf/index.js
@@ -160,18 +160,25 @@ class PDF  {
     return typeof prop === type
   }
 
-  create (_content, _stream) {
+  create (content, stream = undefined) {
     try {
-      if (Array.isArray(_content)) {
-        this._setupPrinter()
-        this._applyConfiguration()
-        this._finaliseDefinition(_content)
-        this._generatePDF()
-        this._pipeTo(_stream)
-        return this._end()
-      } else {
+      if (!Array.isArray(content)) {
         throw new Error('Your PDF content must be an Array.')
       }
+
+      this._setupPrinter()
+      this._applyConfiguration()
+      this._finaliseDefinition(content)
+      this._generatePDF()
+
+      // Pipe the content to the stream if a stream is provided
+      if (stream) {
+        this._pipeTo(stream)
+      }
+
+      this._end()
+
+      return this.document
     } catch (error) {
       throw { status: 'error', error: error }
     }


### PR DESCRIPTION
I made a change to the create method and made the stream parameter optional.
This allows me to create a pdf and get the rendered pdf as a return.  This way I can pass it to the put method on the Drive and store it for later use.

```js
const pdf = PDF.create(content)
await Drive.put('hello.pdf', pdf)
```